### PR TITLE
Fix "dauber" typo

### DIFF
--- a/packages/LWT-Bingo/src/util/data/phrases.ts
+++ b/packages/LWT-Bingo/src/util/data/phrases.ts
@@ -229,7 +229,7 @@ const phrases: Phrases = {
   224: 'Get 4 bingos!',
   225: 'Get 5 bingos!',
   226: 'Get 2 bingos!',
-  227: 'You own a bingo dobber',
+  227: 'You own a bingo dauber',
   228: 'played bingo in elementary school',
   229: 'played Gay bingo',
   230: 'played drag bingo',


### PR DESCRIPTION
Fix a small typo on a bingo card. (This PR is mostly meant for testing the bingo deployment process.)