### PR TITLE
Make User menu keyboard-accessible

### DIFF
--- a/packages/LWT-Bingo/src/client/Components/User.tsx
+++ b/packages/LWT-Bingo/src/client/Components/User.tsx
@@ -53,6 +53,12 @@ const User: React.FC = () => {
           <Avatar
             src={user?.photoURL}
             onClick={showUserMenu}
+            onKeyDown={(e) => {
+              if (e.code === "Enter") {
+                e.preventDefault();
+                showUserMenu;
+              }
+            }}
             aria-label="user-menu-button"
             aria-controls={open ? 'menu' : undefined}
             aria-haspopup="true"

--- a/packages/LWT-Bingo/src/client/Components/User.tsx
+++ b/packages/LWT-Bingo/src/client/Components/User.tsx
@@ -58,6 +58,7 @@ const User: React.FC = () => {
             aria-haspopup="true"
             aria-expanded={open ? 'true' : undefined}
             alt={user?.displayName}
+            tabIndex={0}
           />
         )
         /*{ <Typography variant="body2"> {user?.displayName}</Typography>


### PR DESCRIPTION
Resolve two keyboard accessibility issues with the User menu:
- Add User Avatar to tab order, so it can be focused by keyboard.
- If a user presses the Enter key while their User Avatar is focused, open the User Menu. (Previously, this menu could be opened by mouse click but not keyboard. The user can close the menu by pressing Escape.)

Relevant Linear ticket: https://linear.app/incoteam/issue/INC-87/accessibility-google-profile-button-is-not-keyboard-accessible