### PR TITLE
Keyboard accessibility improvements

### DIFF
--- a/packages/InCo_Website/package-lock.json
+++ b/packages/InCo_Website/package-lock.json
@@ -1966,9 +1966,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001704",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz",
-      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==",
+      "version": "1.0.30001731",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+      "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
       "dev": true,
       "funding": [
         {

--- a/packages/InCo_Website/src/components/FAQ/FAQPage.css
+++ b/packages/InCo_Website/src/components/FAQ/FAQPage.css
@@ -36,7 +36,6 @@
   font-weight: 500;
   color: black;
   background-color: white;
-  box-shadow: none;
   padding-left: 0px;
   padding-right: 0px;
 }
@@ -44,11 +43,6 @@
 .accordion-button:not(.collapsed) {
   color: black;
   background-color: white;
-  box-shadow: none;
-}
-
-.accordion-button:focus {
-  box-shadow: none;
 }
 
 .accordion-body {

--- a/packages/InCo_Website/src/components/Navbar/MobileNav/MobileNav.css
+++ b/packages/InCo_Website/src/components/Navbar/MobileNav/MobileNav.css
@@ -11,6 +11,7 @@
     transition: all 0.3s ease;
     transform: translateX(-100vw);
     z-index: 0;
+    visibility: hidden;
 }
 
 .mobile-menu-container {
@@ -24,6 +25,7 @@
 .mobile-menu.active {
     opacity: 1;
     transform: translateX(0);
+    visibility: visible;
 }
 
 .logo-wrapper {

--- a/packages/InCo_Website/src/components/Navbar/MobileNav/MobileNav.jsx
+++ b/packages/InCo_Website/src/components/Navbar/MobileNav/MobileNav.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "./MobileNav.css";
 import { Link } from "react-router-dom";
 

--- a/packages/InCo_Website/src/components/Navbar/NavBar.jsx
+++ b/packages/InCo_Website/src/components/Navbar/NavBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import "./NavBar.css";
 import MobileNav from "./MobileNav/MobileNav";
 import { Link } from "react-router-dom";


### PR DESCRIPTION
This PR addresses these two Linear stories:
- [INC-64: FAQ entries need focus indicator](https://linear.app/incoteam/issue/INC-64/accessibility-faq-entries-need-focus-indicator)
- [INC-65: Duplicate navigation menu for keyboard/screen reader users](https://linear.app/incoteam/issue/INC-65/accessibility-duplicate-navigation-menu-for-keyboardscreen-reader)

Also in this PR:
- Updated the caniuse-lite module to address a warning.
- Removed a couple unused imports in the nav bar files.
