### PR TITLE
Fix hide/close mobile menu visibility

### DIFF
--- a/packages/InCo_Website/src/components/Navbar/MobileNav/MobileNav.css
+++ b/packages/InCo_Website/src/components/Navbar/MobileNav/MobileNav.css
@@ -55,6 +55,10 @@
     animation: fadeIn 2s ease 0s 1 normal forwards;
 }
 
+[aria-label*="open menu"] {
+    visibility: hidden;
+}
+
 .material-symbols-outlined {
     font-size: 2.8rem;
 }
@@ -167,6 +171,12 @@
     min-width: 96%;
 }
 
+@media (max-width: 998px) and (min-width:868px) {
+    [aria-label*="open menu"] {
+        visibility: visible;
+    }
+}
+
 @media(max-width: 869px) and (min-width: 320px) {
     .mobile-menu-container {
         min-width: 55vw;
@@ -184,6 +194,9 @@
         margin-top: 11em;
     }
 
+    [aria-label*="open menu"] {
+        visibility: visible;
+    }
 
     .material-symbols-outlined {
         font-size: 2.8rem;
@@ -193,8 +206,7 @@
         display: block;
     }
 
-    #root>div>div.mobile-menu.active>div>button,
-    #root>div>div.mobile-menu>div>button {
+    #root>div>div.mobile-menu.active>div>button {
         visibility: visible;
     }
 
@@ -211,7 +223,7 @@
         min-width: 100%;
     }
 
-    .menu-btn {
+    [aria-label*="open menu"] {
         visibility: visible;
     }
 
@@ -236,7 +248,7 @@
         padding: 2rem;
     }
 
-    .menu-btn {
+    [aria-label*="open menu"] {
         border-radius: 50%;
         height: 2.6em;
         width: 2.6em;
@@ -272,7 +284,7 @@
         margin-top: 8em;
     }
 
-    .menu-btn {
+    [aria-label*="open menu"] {
         border-radius: 50%;
         height: 2.6em;
         width: 2.6em;

--- a/packages/InCo_Website/src/components/Navbar/NavBar.css
+++ b/packages/InCo_Website/src/components/Navbar/NavBar.css
@@ -165,7 +165,6 @@ a>.nav-play-btn:active:focus:target {
     cursor: pointer;
     transition: all 0.04s ease;
     z-index: 9999;
-    visibility: hidden;
 }
 
 .menu-btn-hidden {
@@ -283,12 +282,6 @@ a>.nav-play-btn:active:focus:target {
         display: none;
     }
 
-    .menu-btn {
-        position: absolute;
-        left: 0;
-        z-index: 9999 !important;
-    }
-
     #root>div>nav>div>div.d-flex.align-items-center.justify-content-between.position-relative.flex-row-reverse>a,
     #root>div>nav>div>div.d-flex.align-items-center.justify-content-between.position-relative.flex-row>a {
         margin: .6em 0;
@@ -318,6 +311,9 @@ a>.nav-play-btn:active:focus:target {
     }
 
     .menu-btn {
+        position: absolute;
+        left: 0;
+        z-index: 9999 !important;
         border-radius: 50%;
         height: 2.6rem;
         width: 2.6rem;
@@ -325,8 +321,11 @@ a>.nav-play-btn:active:focus:target {
         justify-content: center;
         align-items: center;
         margin: 0;
-        visibility: visible;
         transition: all 0.2s ease;
+    }
+
+    [aria-label*="open menu"] {
+        visibility: visible;
     }
 
     .menu-btn>span {


### PR DESCRIPTION
This should be the last thing to close out [INC-65 (Duplicate navigation menu for keyboard/screen reader users)](https://linear.app/incoteam/issue/INC-65/accessibility-duplicate-navigation-menu-for-keyboardscreen-reader): Regardless of browser size, when the mobile menu is closed, the close button should be hidden from screen readers.

Tested in Windows Chrome and Firefox at all browser width breakpoints to make sure the mobile menu still works as expected.